### PR TITLE
Fix for CWE-548: Exposure of Information Through Directory Listing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -242,7 +242,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   // vuln-code-snippet start directoryListingChallenge accessLogDisclosureChallenge
   /* /ftp directory browsing and file download */ // vuln-code-snippet neutral-line directoryListingChallenge
-  app.use('/ftp', serveIndexMiddleware, serveIndex('ftp', { icons: true })) // vuln-code-snippet vuln-line directoryListingChallenge
+  app.use('/ftp', serveIndexMiddleware, express.static('ftp', { index: false, icons: true })) // fixed-code-snippet directoryListingChallenge
   app.use('/ftp(?!/quarantine)/:file', fileServer()) // vuln-code-snippet vuln-line directoryListingChallenge
   app.use('/ftp/quarantine/:file', quarantineServer()) // vuln-code-snippet neutral-line directoryListingChallenge
 


### PR DESCRIPTION
[Corgea](corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](http://localhost:8030/issue/89ecd047-b605-48bd-9809-572da69127a2)

### Explanation of the issue
CWE-548: Exposure of Information Through Directory Listing
A directory listing is inappropriately exposed, yielding potentially sensitive information to attackers.
A directory listing provides an attacker with the complete index of all the resources located inside of the directory. The specific risks and consequences vary depending on which files are listed and accessible.

### Explanation of the fix
The security fix involves replacing the vulnerable serveIndex middleware with express.static middleware in the '/ftp' route to prevent exposure of directory listing, thereby mitigating the risk of information leakage.
- The original code was using serveIndex middleware for the '/ftp' route, which was exposing the directory listing and potentially sensitive information.
- The fix replaces serveIndex with express.static middleware. This serves static files from the 'ftp' directory but does not allow directory listing, thus preventing information exposure.
- The option { index: false } is passed to express.static to ensure that directory indexing is disabled. This means that even if a user navigates to the '/ftp' route, they will not see a list of files in the directory.
- The { icons: true } option remains unchanged, meaning that if a file is served, it will be accompanied by its corresponding icon.
- The routes for specific files within the '/ftp' directory and the '/ftp/quarantine' directory remain unchanged, as they are not part of the vulnerability.