### PR TITLE
Fix for CWE-548: Exposure of Information Through Directory Listing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -247,7 +247,10 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.use('/ftp/quarantine/:file', quarantineServer()) // vuln-code-snippet neutral-line directoryListingChallenge
 
   /* /encryptionkeys directory browsing */
-  app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+  // app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+  app.use('/encryptionkeys', (req: Request, res: Response, next: NextFunction) => {
+    res.status(403).send('Access denied');
+  });
   app.use('/encryptionkeys/:file', keyServer())
 
   /* /logs directory browsing */ // vuln-code-snippet neutral-line accessLogDisclosureChallenge


### PR DESCRIPTION
[Corgea](corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/3c2ff8bd-2b27-47f7-9f53-b6edc86b57c6)

### Explanation of the issue
CWE-548: Exposure of Information Through Directory Listing
A directory listing is inappropriately exposed, yielding potentially sensitive information to attackers.
A directory listing provides an attacker with the complete index of all the resources located inside of the directory. The specific risks and consequences vary depending on which files are listed and accessible.

### Explanation of the fix
The fix involves disabling directory listing for the '/encryptionkeys' path and instead sending a '403 Access Denied' response to any requests to this path.
- The original code was using 'serveIndexMiddleware' and 'serveIndex' to provide a directory listing of '/encryptionkeys'. This was exposing potentially sensitive information.
- The fix comments out the original 'app.use' line for '/encryptionkeys' that was causing the directory listing.
- A new 'app.use' line is added for '/encryptionkeys'. This uses an Express middleware function that takes a request (req), a response (res), and a next function as parameters.
- The middleware function responds to any request to '/encryptionkeys' with a status of 403 (Access Denied) and a message of 'Access denied'.
- This effectively blocks any attempts to list the directory contents of '/encryptionkeys', mitigating the information exposure vulnerability.