### PR TITLE
Fix for CWE-548: Exposure of Information Through Directory Listing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -247,7 +247,8 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.use('/ftp/quarantine/:file', quarantineServer()) // vuln-code-snippet neutral-line directoryListingChallenge
 
   /* /encryptionkeys directory browsing */
-  app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+  // app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+  app.use('/encryptionkeys', serveIndexMiddleware, express.static('encryptionkeys', { index: false }))
   app.use('/encryptionkeys/:file', keyServer())
 
   /* /logs directory browsing */ // vuln-code-snippet neutral-line accessLogDisclosureChallenge


### PR DESCRIPTION
[Corgea](corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](http://localhost:8030/issue/45585eae-f894-4f63-b42a-6e97eceed5ba)

### Explanation of the issue
CWE-548: Exposure of Information Through Directory Listing
A directory listing is inappropriately exposed, yielding potentially sensitive information to attackers.
A directory listing provides an attacker with the complete index of all the resources located inside of the directory. The specific risks and consequences vary depending on which files are listed and accessible.

### Explanation of the fix
The security fix involves disabling directory listing for the '/encryptionkeys' route and serving static files instead, to prevent exposure of sensitive information.
- The original code was using 'serveIndex' middleware for the '/encryptionkeys' route, which exposed a directory listing, potentially revealing sensitive information.
- The fix comments out the line of code that was causing the directory listing.
- Instead of serving an index, the updated code uses 'express.static' to serve static files from the 'encryptionkeys' directory. The 'index' option is set to false to prevent directory listing.
- This change ensures that when the '/encryptionkeys' route is accessed, a directory listing is not exposed, mitigating the risk of information exposure.
- The 'keyServer()' middleware is still used for handling individual file requests within the '/encryptionkeys' directory.