### PR TITLE
Fix for CWE-548: Exposure of Information Through Directory Listing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -251,7 +251,9 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.use('/encryptionkeys/:file', keyServer())
 
   /* /logs directory browsing */ // vuln-code-snippet neutral-line accessLogDisclosureChallenge
-  app.use('/support/logs', serveIndexMiddleware, serveIndex('logs', { icons: true, view: 'details' })) // vuln-code-snippet vuln-line accessLogDisclosureChallenge
+  app.use('/support/logs', (req: Request, res: Response, next: NextFunction) => {
+    res.status(403).send('Access denied');
+  });
   app.use('/support/logs', verify.accessControlChallenges()) // vuln-code-snippet hide-line
   app.use('/support/logs/:file', logFileServer()) // vuln-code-snippet vuln-line accessLogDisclosureChallenge
 


### PR DESCRIPTION
[Corgea](corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](https://doghouse.corgeainternal.dev/issue/ca119cc7-a2fa-4dfc-afb2-f0a552954d3f)

### Explanation of the issue
CWE-548: Exposure of Information Through Directory Listing
A directory listing is inappropriately exposed, yielding potentially sensitive information to attackers.
A directory listing provides an attacker with the complete index of all the resources located inside of the directory. The specific risks and consequences vary depending on which files are listed and accessible.

### Explanation of the fix
The fix involves replacing the directory listing middleware with a middleware that responds with a 403 (Access Denied) status, thus preventing exposure of sensitive information through directory listing.
- The original code used the 'serveIndex' middleware for the '/support/logs' route, which allowed directory listing and potentially exposed sensitive information.
- The fix replaces this middleware with a custom one that simply responds with a 403 status code and a 'Access denied' message. This effectively blocks any attempts to list the directory contents.
- The middleware for serving individual log files ('/support/logs/:file') remains unchanged, meaning specific log files can still be accessed if the exact path is known.