### PR TITLE
Fix for CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')

### DIFF
--- a/routes/vulnCodeSnippet.ts
+++ b/routes/vulnCodeSnippet.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import path from 'path'
 import { type NextFunction, type Request, type Response } from 'express'
 import fs from 'fs'
 import yaml from 'js-yaml'
@@ -91,7 +92,9 @@ exports.checkVulnLines = () => async (req: Request<Record<string, unknown>, Reco
   const verdict = getVerdict(vulnLines, neutralLines, selectedLines)
   let hint
   if (fs.existsSync('./data/static/codefixes/' + key + '.info.yml')) {
-    const codingChallengeInfos = yaml.load(fs.readFileSync('./data/static/codefixes/' + key + '.info.yml', 'utf8'))
+    
+    const safeKey = path.basename(key);
+    const codingChallengeInfos = yaml.load(fs.readFileSync(path.join('./data/static/codefixes/', safeKey + '.info.yml'), 'utf8'))
     if (codingChallengeInfos?.hints) {
       if (accuracy.getFindItAttempts(key) > codingChallengeInfos.hints.length) {
         if (vulnLines.length === 1) {


### PR DESCRIPTION
[Corgea](https://www.corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/5752569b-11af-4499-be61-55fc13565af6)

### Explanation of the issue
CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
The product uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the product does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory.

Many file operations are intended to take place within a restricted directory. By using special elements such as ".." and "/" separators, attackers can escape outside of the restricted location to access files or directories that are elsewhere on the system. One of the most common special elements is the "../" sequence, which in most modern operating systems is interpreted as the parent directory of the current location. This is referred to as relative path traversal. Path traversal also covers the use of absolute pathnames such as "/usr/local/bin", which may also be useful in accessing unexpected files. This is referred to as absolute path traversal.
In many programming languages, the injection of a null byte (the 0 or NUL) may allow an attacker to truncate a generated filename to widen the scope of attack. For example, the product may add ".txt" to any pathname, thus limiting the attacker to text files, but a null injection may effectively remove this restriction.


### Explanation of the fix
The fix addresses a Path Traversal vulnerability by sanitizing the 'key' input to ensure it only contains the base filename, preventing directory traversal.
- The 'path' module is imported to sanitize the 'key' input.
- The 'basename' function from the 'path' module is used to extract the base filename from the 'key' input. This function removes any directory paths from the input, preventing directory traversal.
- The sanitized 'key' (now 'safeKey') is used to construct the file path for the 'fs.readFileSync' function. This ensures that the file read operation can only occur within the intended directory.
- This fix prevents an attacker from using special elements like ".." or "/" to escape the restricted directory and access files or directories elsewhere on the system.