### PR TITLE
Fix for CWE-548: Exposure of Information Through Directory Listing

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -247,7 +247,9 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.use('/ftp/quarantine/:file', quarantineServer()) // vuln-code-snippet neutral-line directoryListingChallenge
 
   /* /encryptionkeys directory browsing */
-  app.use('/encryptionkeys', serveIndexMiddleware, serveIndex('encryptionkeys', { icons: true, view: 'details' }))
+  app.use('/encryptionkeys', (req: Request, res: Response, next: NextFunction) => {
+    res.status(403).send('Access denied');
+  });
   app.use('/encryptionkeys/:file', keyServer())
 
   /* /logs directory browsing */ // vuln-code-snippet neutral-line accessLogDisclosureChallenge


### PR DESCRIPTION
[Corgea](https://www.corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/e4ba7794-b80b-4911-bb1b-807d679a1a87)

### Explanation of the issue
CWE-548: Exposure of Information Through Directory Listing
A directory listing is inappropriately exposed, yielding potentially sensitive information to attackers.
A directory listing provides an attacker with the complete index of all the resources located inside of the directory. The specific risks and consequences vary depending on which files are listed and accessible.

### Explanation of the fix
The security fix involves replacing the directory listing functionality for the '/encryptionkeys' route with a middleware that sends a '403 Access Denied' response to any request, thus preventing exposure of sensitive information.
- The original code used 'serveIndexMiddleware' and 'serveIndex' to provide a directory listing of '/encryptionkeys', potentially exposing sensitive information.
- The fix replaces this with a middleware function that intercepts requests to '/encryptionkeys'.
- This middleware function immediately responds with a '403 Access Denied' status and message, preventing any directory listing.
- As a result, an attacker cannot gain a complete index of all resources located inside the '/encryptionkeys' directory.
- This effectively mitigates the risk of CWE-548: Exposure of Information Through Directory Listing.