### PR TITLE
Fix for CWE-116: Improper Encoding or Escaping of Output

### DIFF
--- a/frontend/src/app/last-login-ip/last-login-ip.component.ts
+++ b/frontend/src/app/last-login-ip/last-login-ip.component.ts
@@ -33,7 +33,7 @@ export class LastLoginIpComponent {
       payload = jwtDecode(token)
       if (payload.data.lastLoginIp) {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        this.lastLoginIp = this.sanitizer.bypassSecurityTrustHtml(`<small>${payload.data.lastLoginIp}</small>`)
+        this.lastLoginIp = payload.data.lastLoginIp
       }
     }
   }


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in frontend/src/app/last-login-ip/last-login-ip.component.ts.

It is CWE-116: Improper Encoding or Escaping of Output that has a severity of :red_circle: Critical.

### 🪄 Fix explanation
The fix removes the use of &quot;bypassSecurityTrustHtml&quot;, which improperly trusted unescaped HTML content, and directly assigns the IP address to &quot;lastLoginIp&quot;, preventing potential script injection.<br>-        The original code used &quot;bypassSecurityTrustHtml&quot; to render HTML, which could allow script injection if the input was not sanitized.<br>        -        The fix directly assigns &quot;payload.data.lastLoginIp&quot; to &quot;this.lastLoginIp&quot;, avoiding the creation of HTML content.<br>        -        By removing HTML rendering, the fix ensures that the IP address is treated as plain text, mitigating the risk of executing malicious scripts.<br>    

### 💡 Important Instructions
Ensure that <code>payload.data.lastLoginIp</code> is validated as a legitimate IP address format before assignment to prevent any unexpected input handling.

[See the issue and fix in Corgea.](https://ahmad-dev.corgeainternal.dev/issue/519cc425-d1da-4054-840b-8b808516c124)

