### PR TITLE
Fix for CWE-601: URL Redirection to Untrusted Site ('Open Redirect')

### DIFF
--- a/data/static/codefixes/redirectChallenge_3.ts
+++ b/data/static/codefixes/redirectChallenge_3.ts
@@ -12,7 +12,13 @@ export const redirectAllowlist = new Set([
 export const isRedirectAllowed = (url: string) => {
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
-    allowed = allowed || url.includes(escapeHTML(allowedUrl))
+    try {
+      const parsedUrl = new URL(url);
+      const allowedParsedUrl = new URL(allowedUrl);
+      allowed = allowed || (parsedUrl.origin === allowedParsedUrl.origin && parsedUrl.pathname === allowedParsedUrl.pathname);
+    } catch (e) {
+      allowed = false;
+    }
   }
   return allowed
 }


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in data/static/codefixes/redirectChallenge_3.ts.

It is CWE-601: URL Redirection to Untrusted Site ('Open Redirect') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix mitigates the open redirect vulnerability by parsing URLs and ensuring that only URLs with matching origins and paths from an allowlist are permitted, preventing redirection to untrusted sites.<br>-        The code now uses &quot;new URL(url)&quot; to parse the input URL, ensuring it is a valid URL format.<br>        -        It compares the &quot;origin&quot; and &quot;pathname&quot; of the input URL with those of the allowlisted URLs using &quot;parsedUrl.origin === allowedParsedUrl.origin&quot;.<br>        -        A &quot;try-catch&quot; block is added to handle any exceptions from invalid URL parsing, setting &quot;allowed&quot; to &quot;false&quot; if an error occurs.<br>        -        The use of &quot;escapeHTML&quot; is removed, as URL parsing inherently handles URL encoding and decoding.<br>    

### 💡 Important Instructions
Ensure that the allowlist contains fully qualified URLs with both origin and path to match against.

[See the issue and fix in Corgea.](https://ahmad-dev.corgeainternal.dev/issue/59c0e315-ee39-406d-bea4-bc645d9a14b7)

