### PR TITLE
Fix for CWE-601: URL Redirection to Untrusted Site ('Open Redirect')

### DIFF
--- a/data/static/codefixes/redirectCryptoCurrencyChallenge_1.ts
+++ b/data/static/codefixes/redirectCryptoCurrencyChallenge_1.ts
@@ -11,7 +11,7 @@ export const redirectAllowlist = new Set([
 export const isRedirectAllowed = (url: string) => {
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
-    allowed = allowed || url.includes(allowedUrl)
+    allowed = allowed || url === allowedUrl
   }
   return allowed
 }


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in data/static/codefixes/redirectCryptoCurrencyChallenge_1.ts.

It is CWE-601: URL Redirection to Untrusted Site ('Open Redirect') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix changes the URL comparison from using &quot;includes&quot; to &quot;===&quot;, ensuring only exact matches from the allowlist are permitted, preventing open redirects to untrusted sites.<br>-        The original code used &quot;url.includes(allowedUrl)&quot;, which allowed partial matches, enabling potential redirects to malicious sites.<br>        -        The fix replaces &quot;includes&quot; with &quot;===&quot;, ensuring only exact URL matches from the &quot;redirectAllowlist&quot; are allowed.<br>        -        This change prevents attackers from exploiting partial matches to redirect users to untrusted sites.<br>        -        The function &quot;isRedirectAllowed&quot; now returns &quot;true&quot; only if the entire URL matches an entry in the allowlist.<br>    

### 💡 Important Instructions
Ensure the <code>redirectAllowlist</code> contains all necessary URLs for legitimate redirects, as only exact matches will be allowed.

[See the issue and fix in Corgea.](https://ahmad-dev.corgeainternal.dev/issue/9076ba6a-c759-481c-b4cc-33b6f8d505ce)

