### PR TITLE
Fix for CWE-601: URL Redirection to Untrusted Site ('Open Redirect')

### DIFF
--- a/data/static/codefixes/redirectCryptoCurrencyChallenge_4.ts
+++ b/data/static/codefixes/redirectCryptoCurrencyChallenge_4.ts
@@ -11,7 +11,7 @@ export const redirectAllowlist = new Set([
 export const isRedirectAllowed = (url: string) => {
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
-    allowed = allowed || url.includes(allowedUrl)
+    allowed = allowed || url === allowedUrl
   }
   return allowed
 }


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in data/static/codefixes/redirectCryptoCurrencyChallenge_4.ts.

It is CWE-601: URL Redirection to Untrusted Site ('Open Redirect') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix changes the URL comparison from using &quot;includes&quot; to strict equality, ensuring only exact matches from the allowlist are permitted, thus preventing open redirects to untrusted sites.<br>-        The original code used &quot;url.includes(allowedUrl)&quot;, which allowed partial matches, enabling potential redirects to malicious sites.<br>        -        The fix replaces &quot;includes&quot; with &quot;===&quot;, ensuring only exact URL matches from the &quot;redirectAllowlist&quot; are allowed.<br>        -        This change prevents attackers from exploiting partial URL matches to redirect users to untrusted sites.<br>        -        The &quot;redirectAllowlist&quot; must contain only fully trusted URLs to ensure security.<br>    

### 💡 Important Instructions
Ensure the <code>redirectAllowlist</code> is populated with complete and trusted URLs only, as partial matches are no longer valid.

[See the issue and fix in Corgea.](https://ahmad-dev.corgeainternal.dev/issue/6a6b3cb9-41ef-42f7-8662-5c9740baf4cc)

